### PR TITLE
Create user failing with ORA-28003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog oraclehelper
 
+## 0.4.1 (Januari 2, 2020)
+
+* Bug: Adding special character and numeric to the password. So create user will not fail if using `ORA12C_STIG_VERIFY_FUNCTION`. Closing issue #30.
+
 ## 0.4.0 (October 14, 2019 )
 
 * feature: updating dependency

--- a/oraclehelper/user.go
+++ b/oraclehelper/user.go
@@ -99,6 +99,8 @@ func (u *userService) ReadUser(tf ResourceUser) (*User, error) {
 func (u *userService) CreateUser(tf ResourceUser) error {
 	log.Println("[DEBUG] CreateUser")
 	password := acctest.RandStringFromCharSet(20, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuwxyz")
+	// Adding some special character if you are using t ex ORA12C_STIG_VERIFY_FUNCTION
+	password += "!1"
 	sqlCommand := fmt.Sprintf("create user %s identified by %s", tf.Username, password)
 
 	if tf.DefaultTablespace != "" {


### PR DESCRIPTION
create user statement failing if using t ex password function ORA12C_STIG_VERIFY_FUNCTION.